### PR TITLE
Quick fix for HFSPath normalization

### DIFF
--- a/Source/HoudiniEngineEditor/HoudiniEngineEditor.Build.cs
+++ b/Source/HoudiniEngineEditor/HoudiniEngineEditor.Build.cs
@@ -181,6 +181,7 @@ public class HoudiniEngineEditor : ModuleRules
 
         // Find HFS
         string HFSPath = GetHFSPath();
+        HFSPath = HFSPath.Replace("\\", "/");
         if( HFSPath != "" )
         {
             PlatformID buildPlatformId = Environment.OSVersion.Platform;

--- a/Source/HoudiniEngineRuntime/HoudiniEngineRuntime.Build.cs
+++ b/Source/HoudiniEngineRuntime/HoudiniEngineRuntime.Build.cs
@@ -204,7 +204,8 @@ public class HoudiniEngineRuntime : ModuleRules
 
         // Find HFS
         string HFSPath = GetHFSPath();
-        if( HFSPath != "" )
+        HFSPath = HFSPath.Replace("\\", "/");
+        if ( HFSPath != "" )
         {
             string Log = string.Format("Houdini Engine : Found Houdini in {0}", HFSPath );
             System.Console.WriteLine( Log ); 


### PR DESCRIPTION
MS Visual Studio only fix.
Quick fix for problems like:  _HoudiniEngineUtils.cpp(6303): error C4129: 'XXX': unrecognized character escape sequence_