### PR TITLE
FIX: Typo in in finding Houdini plugin folder

### DIFF
--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineEditor.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineEditor.cpp
@@ -62,6 +62,8 @@
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
 
+#include "Interfaces/IPluginManager.h"
+
 #define LOCTEXT_NAMESPACE HOUDINI_LOCTEXT_NAMESPACE 
 
 #define IMAGE_BRUSH( RelativePath, ... ) FSlateImageBrush( StyleSet->RootToContentDir( RelativePath, TEXT(".png") ), __VA_ARGS__ )
@@ -794,9 +796,14 @@ FHoudiniEngineEditor::GetHoudiniEnginePluginDir()
     if ( FPaths::DirectoryExists(EnginePluginDir) )
         return EnginePluginDir;
 
-    FString ProjectPluginDir = FPaths::EnginePluginsDir() / TEXT("Runtime/HoudiniEngine");
+    FString ProjectPluginDir = FPaths::ProjectPluginsDir() / TEXT("Runtime/HoudiniEngine");
     if ( FPaths::DirectoryExists(ProjectPluginDir) )
         return ProjectPluginDir;
+
+	TSharedPtr<IPlugin> HoudiniPlugin = IPluginManager::Get().FindPlugin(TEXT("HoudiniEngine"));
+	FString PluginBaseDir = HoudiniPlugin.IsValid() ? HoudiniPlugin->GetBaseDir() : EnginePluginDir;
+	if ( FPaths::DirectoryExists(PluginBaseDir) )
+		return PluginBaseDir;
 
     HOUDINI_LOG_WARNING(TEXT("Could not find the Houdini Engine plugin's directory"));
 


### PR DESCRIPTION
  -Also added a more robust version by using IPluginManager::Get() to Get
   the directory where the module resides instead of relying on hardcoded
   paths