### PR TITLE
Assign physical material to landscape layer info from primitive attribute

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.cpp
@@ -3453,6 +3453,22 @@ void FHoudiniLandscapeUtils::GetHeightFieldLandscapeMaterials(
     }
 }
 
+UPhysicalMaterial* FHoudiniLandscapeUtils::GetPhysicalMaterialForLayer( const FHoudiniGeoPartObject& LayerGeo )
+{
+	HAPI_AttributeInfo AttribInfoLayer{};
+	TArray< FString > AttribValues;
+	
+	if (!FHoudiniEngineUtils::HapiGetAttributeDataAsString(LayerGeo, "unreal_landscape_layer_physical_material", AttribInfoLayer, AttribValues, 1, HAPI_ATTROWNER_PRIM))
+		return nullptr;
+
+	if (AttribValues.Num() > 0)
+	{
+		return LoadObject<UPhysicalMaterial>(nullptr, *AttribValues[0], nullptr, LOAD_NoWarn, nullptr);
+	}
+
+	return nullptr;
+}
+
 bool FHoudiniLandscapeUtils::CreateLandscapeLayers(
     FHoudiniCookParams& HoudiniCookParams,
     const TArray< const FHoudiniGeoPartObject* >& FoundLayers,
@@ -3554,6 +3570,12 @@ bool FHoudiniLandscapeUtils::CreateLandscapeLayers(
             currentLayerInfo.LayerInfo->bNoWeightBlend = true;
         else
             currentLayerInfo.LayerInfo->bNoWeightBlend = false;
+
+		UPhysicalMaterial* PhysMaterial = FHoudiniLandscapeUtils::GetPhysicalMaterialForLayer(*LayerGeoPartObject);
+		if (PhysMaterial)
+		{
+			currentLayerInfo.LayerInfo->PhysMaterial = PhysMaterial;
+		}
 
         // Mark the package dirty...
         //Package->MarkPackageDirty();

--- a/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.h
@@ -70,6 +70,9 @@ struct HOUDINIENGINERUNTIME_API FHoudiniLandscapeUtils
             UMaterialInterface*& LandscapeMaterial,
             UMaterialInterface*& LandscapeHoleMaterial );
 
+		// Returns the physical material assigned to the layer.
+		static UPhysicalMaterial* GetPhysicalMaterialForLayer(const FHoudiniGeoPartObject& LayerGeo);
+
         // Creates the package needed to store landscape layer infos
         static ULandscapeLayerInfoObject* CreateLandscapeLayerInfoObject( 
             FHoudiniCookParams& HoudiniCookParams, const TCHAR* LayerName, UPackage*& Package );


### PR DESCRIPTION
If a heightfield volume (layer) primitive has the `unreal_landscape_layer_physical_material` string attribute set, then landscape import will create a layer info object that references the physical material.

More info and screenshots are in the project link below.

## Testing Done
I used the [UE4 project and Houdini HDA here](https://github.com/drichardson/UE4Examples/tree/master/HoudiniLandscapeTest) to test.

- Tested with attribute set on layer. Verified physical material correctly assigned.
- Tested with no attribute set on layer. Verified physical material is None.