### PR TITLE
Fix null pointer crash on ServerTravel

### DIFF
--- a/HoudiniEngine.uplugin
+++ b/HoudiniEngine.uplugin
@@ -2,7 +2,7 @@
 	"FileVersion" : 3,
 	"FriendlyName" : "Houdini Engine",
 	"Version" : 17050236,
-	"VersionName" : "17.5.236",
+	"VersionName" : "17.5.229",
 	"CreatedBy" : "Side Effects Software Inc.",
 	"CreatedByURL" : "http://www.sidefx.com",
 	"DocsURL" : "http://www.sidefx.com/docs/unreal/",

--- a/Source/HoudiniEngineEditor/HoudiniEngineEditor.Build.cs
+++ b/Source/HoudiniEngineEditor/HoudiniEngineEditor.Build.cs
@@ -32,7 +32,7 @@
 
 /*
 
-    Houdini Version: 17.5.236
+    Houdini Version: 17.5.229
     Houdini Engine Version: 3.2.40
     Unreal Version: 4.22.0
 
@@ -46,7 +46,7 @@ public class HoudiniEngineEditor : ModuleRules
 {
     private string GetHFSPath()
     {
-        string HoudiniVersion = "17.5.236";
+        string HoudiniVersion = "17.5.229";
         bool bIsRelease = true;
         string HFSPath = "";
         string RegistryPath = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Side Effects Software";

--- a/Source/HoudiniEngineRuntime/HoudiniEngineRuntime.Build.cs
+++ b/Source/HoudiniEngineRuntime/HoudiniEngineRuntime.Build.cs
@@ -32,7 +32,7 @@
 
 /*
 
-    Houdini Version: 17.5.236
+    Houdini Version: 17.5.229
     Houdini Engine Version: 3.2.40
     Unreal Version: 4.22.0
 
@@ -46,7 +46,7 @@ public class HoudiniEngineRuntime : ModuleRules
 {
     private string GetHFSPath()
     {
-        string HoudiniVersion = "17.5.236";
+        string HoudiniVersion = "17.5.229";
         bool bIsRelease = true;
         string HFSPath = "";
         string RegistryPath = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Side Effects Software";

--- a/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.cpp
@@ -2274,14 +2274,17 @@ UHoudiniAssetComponent::SubscribeEditorDelegates()
 void
 UHoudiniAssetComponent::UnsubscribeEditorDelegates()
 {
-    // Remove delegate for asset post import.
-    GEditor->GetEditorSubsystem<UImportSubsystem>()->OnAssetPostImport.Remove(DelegateHandleAssetPostImport);
-
     // Remove delegate for viewport drag and drop events.
     FEditorDelegates::OnApplyObjectToActor.Remove( DelegateHandleApplyObjectToActor );
 
     if ( GEditor )
     {
+        // Remove delegate for asset post import.
+        if (UImportSubsystem* ImportSys = GEditor->GetEditorSubsystem<UImportSubsystem>())
+        {
+            ImportSys->OnAssetPostImport.Remove(DelegateHandleAssetPostImport);
+        }
+
         GEditor->OnActorMoved().RemoveAll( this );
     }
 }

--- a/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.cpp
@@ -48,6 +48,7 @@
 #include "LandscapeStreamingProxy.h"
 #include "LightMap.h"
 #include "Engine/MapBuildDataRegistry.h"
+#include "PhysicalMaterials/PhysicalMaterial.h"
 
 #if WITH_EDITOR
     #include "FileHelpers.h"

--- a/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.cpp
@@ -3453,6 +3453,22 @@ void FHoudiniLandscapeUtils::GetHeightFieldLandscapeMaterials(
     }
 }
 
+UPhysicalMaterial* FHoudiniLandscapeUtils::GetPhysicalMaterialForLayer( const FHoudiniGeoPartObject& LayerGeo )
+{
+	HAPI_AttributeInfo AttribInfoLayer{};
+	TArray< FString > AttribValues;
+	
+	if (!FHoudiniEngineUtils::HapiGetAttributeDataAsString(LayerGeo, "unreal_landscape_layer_physical_material", AttribInfoLayer, AttribValues, 1, HAPI_ATTROWNER_PRIM))
+		return nullptr;
+
+	if (AttribValues.Num() > 0)
+	{
+		return LoadObject<UPhysicalMaterial>(nullptr, *AttribValues[0], nullptr, LOAD_NoWarn, nullptr);
+	}
+
+	return nullptr;
+}
+
 bool FHoudiniLandscapeUtils::CreateLandscapeLayers(
     FHoudiniCookParams& HoudiniCookParams,
     const TArray< const FHoudiniGeoPartObject* >& FoundLayers,
@@ -3554,6 +3570,12 @@ bool FHoudiniLandscapeUtils::CreateLandscapeLayers(
             currentLayerInfo.LayerInfo->bNoWeightBlend = true;
         else
             currentLayerInfo.LayerInfo->bNoWeightBlend = false;
+
+		UPhysicalMaterial* PhysMaterial = FHoudiniLandscapeUtils::GetPhysicalMaterialForLayer(*LayerGeoPartObject);
+		if (PhysMaterial)
+		{
+			currentLayerInfo.LayerInfo->PhysMaterial = PhysMaterial;
+		}
 
         // Mark the package dirty...
         //Package->MarkPackageDirty();

--- a/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.h
@@ -70,6 +70,9 @@ struct HOUDINIENGINERUNTIME_API FHoudiniLandscapeUtils
             UMaterialInterface*& LandscapeMaterial,
             UMaterialInterface*& LandscapeHoleMaterial );
 
+		// Returns the physical material assigned to the layer.
+		static UPhysicalMaterial* GetPhysicalMaterialForLayer(const FHoudiniGeoPartObject& LayerGeo);
+
         // Creates the package needed to store landscape layer infos
         static ULandscapeLayerInfoObject* CreateLandscapeLayerInfoObject( 
             FHoudiniCookParams& HoudiniCookParams, const TCHAR* LayerName, UPackage*& Package );


### PR DESCRIPTION
This PR fixes the crash reported here:

Side Effects Support Ticket: #76417
Side Effects bug #96327

The crash was isolated with this test project:
https://github.com/drichardson/HoudiniBugs/tree/master/TravelCrash

(specifically in the [test-pr-98 branch](https://github.com/drichardson/HoudiniBugs/tree/test-pr-98/TravelCrash))



