### PR TITLE
Fix Undo triggered serialization crash.

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.cpp
@@ -3363,7 +3363,7 @@ UHoudiniAssetComponent::Serialize( FArchive & Ar )
     }
 
     // Serialize format version.
-    uint32 HoudiniAssetComponentVersion = GetLinkerCustomVersion( FHoudiniCustomSerializationVersion::GUID );
+    uint32 HoudiniAssetComponentVersion = Ar.CustomVer( FHoudiniCustomSerializationVersion::GUID );
     Ar << HoudiniAssetComponentVersion;
 
     // Serialize component state.
@@ -5523,7 +5523,7 @@ UHoudiniAssetComponent::SerializeInstanceInputs( FArchive & Ar )
         if ( !Ar.IsTransacting() )
             ClearInstanceInputs();
         
-        int32 HoudiniAssetComponentVersion = GetLinkerCustomVersion( FHoudiniCustomSerializationVersion::GUID );
+        int32 HoudiniAssetComponentVersion = Ar.CustomVer( FHoudiniCustomSerializationVersion::GUID );
         if ( HoudiniAssetComponentVersion > VER_HOUDINI_ENGINE_COMPONENT_PARAMETER_NAME_MAP )
         {
             Ar << InstanceInputs;


### PR DESCRIPTION
Fix crash when Undo triggers serialization, as Epic Games staff Steve.Robb suggested, using "Ar.CustomVer" to replace "GetLinkerCustomVersion".

UDN ref:https://udn.unrealengine.com/questions/499205/how-to-make-getlinkercustomversion-return-correct.html

The crash is due to sometimes GetLinkerCustomVersion return -1 and cause if ( HoudiniAssetComponentVersion > VER_HOUDINI_ENGINE_COMPONENT_PARAMETER_NAME_MAP ) to evaluate to false, then the wrong serialization code path is triggered, thus the crash.

![crashcallstack](https://user-images.githubusercontent.com/3135621/57996995-11797d80-7afd-11e9-8b31-79fa7a78f36b.png)
