### PR TITLE
Fix nil matrix error when importing flat heightfields

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniLandscapeUtils.cpp
@@ -562,6 +562,10 @@ FHoudiniLandscapeUtils::ConvertHeightfieldDataToLandscapeData(
     // If the data was resized and not expanded, we need to modify the landscape's scale
     LandscapeScale *= LandscapeResizeFactor;
 
+	// Don't allow a zero scale, as this results in divide by 0 operations in FMatrix::InverseFast in the landscape component.
+	if (FMath::IsNearlyZero(LandscapeScale.Z))
+	    LandscapeScale.Z = 1.0f;
+
     // We'll use the position from Houdini, but we will need to offset the Z Position to center the 
     // values properly as the data has been offset by the conversion to uint16
     FVector LandscapePosition = CurrentVolumeTransform.GetLocation();


### PR DESCRIPTION
This addresses a problem that occurs when importing a flat heightfield.

The flat heightfield was creating a `LandscapeTransform` with a 0 `Z` component, which caused the following message to be logged when `FMatrix::InverseFast` was called from `FLandscapeComponentSceneProxy::OnTransformChanged`:

```
LogUnrealMath: Error: FMatrix::InverseFast(), trying to invert a NIL matrix, this results in NaNs! Use Inverse() instead.
```