### PR TITLE
Bug Fix: UHoudiniAssetInstanceInput::CreateInstanceInputField()

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniAssetInstanceInput.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniAssetInstanceInput.cpp
@@ -620,15 +620,15 @@ UHoudiniAssetInstanceInput::CreateInstanceInputField(
 {
     UHoudiniAssetInstanceInputField * HoudiniAssetInstanceInputField = nullptr;
 
-    // Locate all fields which have this static mesh set as original mesh.
-    TArray< UHoudiniAssetInstanceInputField * > CandidateFields = InstanceInputFields;
-    CandidateFields.FilterByPredicate( [&]( const UHoudiniAssetInstanceInputField* Field ) {
-        return Field->GetOriginalObject() == InstancedObject;
-    } );
+    // Locate field which have this static mesh set as original mesh.
+	UHoudiniAssetInstanceInputField** FoundField = InstanceInputFields.FindByPredicate([&](const UHoudiniAssetInstanceInputField* Field)
+	{
+		return Field->GetOriginalObject() == InstancedObject;
+	});
 
-    if ( CandidateFields.Num() > 0 )
-    {
-        HoudiniAssetInstanceInputField = CandidateFields[ 0 ];
+	if (FoundField)
+	{
+		HoudiniAssetInstanceInputField = *FoundField;
         InstanceInputFields.RemoveSingleSwap( HoudiniAssetInstanceInputField, false );
 
         TArray< int32 > MatchingIndices;


### PR DESCRIPTION
I fixed UHoudiniAssetInstanceInput::CreateInstanceInputField().
Original code uses FilterByPredicate(). But it needs to receive return value. Original code do nothing.
Original code uses only first element of CandidateFields. So FindByPredicate() is better.
This change will fix an issue of overriding Houdini Instanced Inputs on UE4. The issue is that if you override Houdini Instanced Inputs and change any parameter of HoudiniAssetComponent, then Houdini Instanced Inputs array's order randomly changes.