### PR TITLE
Makes Houdini18.0-Unreal4.26 branch able to be compiled for Unreal Engine 4.26 on Linux

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniAssetInput.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniAssetInput.cpp
@@ -530,7 +530,7 @@ UHoudiniAssetInput::DisconnectAndDestroyInputAsset()
             if ( FHoudiniEngineUtils::IsHoudiniNodeValid( ParentId ) )
                 FHoudiniEngineUtils::DestroyHoudiniAsset( ParentId );
 
-                FHoudiniEngineUtils::DestroyHoudiniAsset( ConnectedAssetId );
+            FHoudiniEngineUtils::DestroyHoudiniAsset( ConnectedAssetId );
         }
         ConnectedAssetId = -1;
         if ( ChoiceIndex == EHoudiniAssetInputType::WorldInput )
@@ -1196,7 +1196,7 @@ UHoudiniAssetInput::UpdateObjectMergePackBeforeMerge()
     else if (ChoiceIndex == EHoudiniAssetInputType::WorldInput)
         NumberOfInputObjects = InputOutlinerMeshArray.Num();
 
-	if (bIsObjectPathParameter)
+    if (bIsObjectPathParameter)
 	{
 		// Directly change the Parameter xformtype
 		if (HAPI_RESULT_SUCCESS == FHoudiniApi::SetParmIntValue(

--- a/Source/HoudiniEngineRuntime/Private/HoudiniEngineBakeUtils.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniEngineBakeUtils.cpp
@@ -1446,7 +1446,7 @@ FHoudiniEngineBakeUtils::BakeCreateMaterialPackageForComponent(
     if ( !HoudiniAsset || HoudiniAsset->IsPendingKill() )
         return nullptr;
 
-	FString MaterialDescriptor;
+    FString MaterialDescriptor;
     if( HoudiniCookParams.MaterialAndTextureBakeMode != EBakeMode::Intermediate )
         MaterialDescriptor = HoudiniAsset->GetName() + TEXT( "_material_" ) + FString::FromInt( MaterialInfo.nodeId ) + TEXT( "_" );
     else

--- a/Source/HoudiniEngineRuntime/Private/HoudiniEngineUtils.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniEngineUtils.cpp
@@ -9683,7 +9683,7 @@ bool FHoudiniEngineUtils::ModifyUPropertyValueOnObject(
     if ( !MeshComponent || MeshComponent->IsPendingKill() || !FoundProperty )
         return false;
 
-	FProperty* InnerProperty = FoundProperty;
+    FProperty* InnerProperty = FoundProperty;
     int32 NumberOfProperties = 1;
 
 	FArrayProperty* ArrayProperty = CastField< FArrayProperty >(FoundProperty);


### PR DESCRIPTION
This PR makes the Houdini18.0-Unreal4.26 branch compilable for Unreal Engine 4.26 on Linux.

Unreal Engine 4.26 has bundled a newer version of clang that stops compiling code when it is unhappy with code indentation.  If we take the Houdini18.0-Unreal4.26 branch as of 2020-12-10 and compile it with Unreal Engine 4.26, the compilation fails.  This PR fixes the code indentation.

Thanks!