### PR TITLE
Bug Fix:Add HoudiniAssetComponent will be crash

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniEngineManager.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniEngineManager.cpp
@@ -177,7 +177,7 @@ FHoudiniEngineManager::Tick(float DeltaTime)
 			
 			{
 				UWorld* World = CurrentComponent->GetWorld();
-				if (World && World->IsPlayingReplay() || World->IsPlayInEditor())
+				if (World && (World->IsPlayingReplay() || World->IsPlayInEditor()))
 				{
 					if (!CurrentComponent->IsPlayInEditorRefinementAllowed())
 					{


### PR DESCRIPTION
1.Steps to reproduce the bug：
(1)create a new blueprintcalss
(2)add component "HoudiniAssetBlueprintComponent" ,the ue4 editor will be crash
Change:
Old:
if (World && World->IsPlayingReplay() || World->IsPlayInEditor())
New:
if (World && (World->IsPlayingReplay() || World->IsPlayInEditor()))
This conditional statement cannot prevent: "World->IsPlayInEditor()" be called when World==nullptr