### PR TITLE
Added parentheses around ambiguous and/or expression

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniEngineManager.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniEngineManager.cpp
@@ -177,7 +177,7 @@ FHoudiniEngineManager::Tick(float DeltaTime)
 			
 			{
 				UWorld* World = CurrentComponent->GetWorld();
-				if (World && World->IsPlayingReplay() || World->IsPlayInEditor())
+				if (World && (World->IsPlayingReplay() || World->IsPlayInEditor()))
 				{
 					if (!CurrentComponent->IsPlayInEditorRefinementAllowed())
 					{


### PR DESCRIPTION
This fixes a Linux compile warning which will fail compilation if using `-Werror=logical-not-parentheses`.

Fixes #142.