### PR TITLE
Fix UE5 Crash when input asset is a datatable

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniInputTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniInputTranslator.cpp
@@ -3310,7 +3310,7 @@ FHoudiniInputTranslator::HapiCreateInputNodeForDataTable(const FString& InNodeNa
 
 		// Create an array
 		TArray<FString> ObjectPaths;
-		ObjectPaths.SetNumUninitialized(NumRows);
+		ObjectPaths.AddDefaulted(NumRows);
 		for (int32 n = 0; n < ObjectPaths.Num(); n++)
 			ObjectPaths[n] = ObjectPathName;
 
@@ -3339,7 +3339,7 @@ FHoudiniInputTranslator::HapiCreateInputNodeForDataTable(const FString& InNodeNa
 
 		// Create an array
 		TArray<FString> RowStructNames;
-		RowStructNames.SetNumUninitialized(NumRows);
+		RowStructNames.AddDefaulted(NumRows);
 		for (int32 n = 0; n < RowStructNames.Num(); n++)
 			RowStructNames[n] = RowStructName;
 


### PR DESCRIPTION
Use SetNumUninitialized to initialize a TArray<FString> will cause a crash in UE5.