### PR TITLE
Fix for compilation in cooked builds

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniAssetBlueprintComponent.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniAssetBlueprintComponent.cpp
@@ -2286,6 +2286,7 @@ UHoudiniAssetBlueprintComponent::CacheBlueprintData()
 	CachedAssetEditorSubsystem = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>();
 #endif
 	
+#if WITH_EDITORONLY_DATA
 	UBlueprintGeneratedClass* BPGC = Cast<UBlueprintGeneratedClass>(GetOuter());
 	if (BPGC)
 	{
@@ -2297,6 +2298,7 @@ UHoudiniAssetBlueprintComponent::CacheBlueprintData()
 		// Dealing with a component instance.
 		CachedBlueprint = Cast<UBlueprint>(GetOuter()->GetClass()->ClassGeneratedBy);
 	}
+#endif
 
 	if (CreationMethod != EComponentCreationMethod::SimpleConstructionScript)
 		return;


### PR DESCRIPTION
`ClassGeneratedBy` is only available with `WITH_EDITORONLY_DATA`