### PR TITLE
Fix Nanite FallbackPercentTriangles param being copied from the wrong attribute

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniMeshTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniMeshTranslator.cpp
@@ -1499,18 +1499,19 @@ FHoudiniMeshTranslator::UpdateStaticMeshNaniteSettings(const int32& GeoId, const
 		StaticMesh->NaniteSettings.PositionPrecision = IntData[0];
 	}
 
-	// Finally look for the percent triangle attributer, zero by default (no triangles)
-	StaticMesh->NaniteSettings.FallbackPercentTriangles = 0.0f;
+	// Finally look for the percent triangle attributer, one by default (all triangles)
+	// as this mesh is also used as in physics engine as the complex collision version
+	StaticMesh->NaniteSettings.FallbackPercentTriangles = 1.0f;
 	TArray<float> FloatData;
 
 	// Look for a specific prim attribute first
 	if (!FHoudiniEngineUtils::HapiGetAttributeDataAsFloat(
-		GeoId, PartId, HAPI_UNREAL_ATTRIB_NANITE_POSITION_PRECISION,
+		GeoId, PartId, HAPI_UNREAL_ATTRIB_NANITE_PERCENT_TRIANGLES,
 		AttributeInfo, FloatData, 1, HAPI_ATTROWNER_PRIM, PrimIndex, 1))
 	{
 		//Global search for the attribute
 		FHoudiniEngineUtils::HapiGetAttributeDataAsFloat(
-			GeoId, PartId, HAPI_UNREAL_ATTRIB_NANITE_POSITION_PRECISION,
+			GeoId, PartId, HAPI_UNREAL_ATTRIB_NANITE_PERCENT_TRIANGLES,
 			AttributeInfo, FloatData, 1, HAPI_ATTROWNER_INVALID, 0, 1);
 	}
 


### PR DESCRIPTION
It seems like a copy and paste error.
I've changed ```FallbackPercentTriangles``` to use the engine default of 1, otherwise any imported mesh that uses Nanite will NOT have any collisions in the physics engine when doing complex collision queries, as the complex physics scene would have a collision mesh with no vertices for that static mesh.

You might also want to expose ```FMeshNaniteSettings::FallbackRelativeError``` as with the default value of 1, more complex meshes are simplified to a fallback mesh with massive holes in them, so we manually need to set it back to 0 on some meshes. Though this is more of an engine issue.