### PR TITLE
Fixed Linux compile issue caused by mixed tabs and spaces

### DIFF
--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineDetails.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineDetails.cpp
@@ -1124,8 +1124,8 @@ FHoudiniEngineDetails::CreateAssetOptionsWidgets(
 
 	auto IsCheckedParameterChangedLambda = [MainHAC]()
 	{
-      	if (!IsValidWeakPointer(MainHAC))
-      		return ECheckBoxState::Unchecked;
+		if (!IsValidWeakPointer(MainHAC))
+			return ECheckBoxState::Unchecked;
 
 		return MainHAC->bCookOnParameterChange ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
 	};


### PR DESCRIPTION
Fixes this compile warning-as-error on Linux:
```
/Engine/Plugins/Runtime/HoudiniEngine/Source/HoudiniEngineEditor/Private/HoudiniEngineDetails.cpp:1130:3: error: misleading indentation; statement is not part of the previous 'if' [-Werror,-Wmisleading-indentation]
                  return MainHAC->bCookOnParameterChange ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
```