### PR TITLE
Fix for bug 119976 - Houdini Unreal asset paths not being sanitized

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniEngineUtils.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniEngineUtils.cpp
@@ -92,6 +92,7 @@
 #if WITH_EDITOR
 	#include "EditorModeManager.h"
 	#include "EditorModes.h"
+	#include "EditorFramework/AssetImportData.h"
 #endif
 
 #define LOCTEXT_NAMESPACE HOUDINI_LOCTEXT_NAMESPACE
@@ -1546,9 +1547,9 @@ FHoudiniEngineUtils::LoadHoudiniAsset(const UHoudiniAsset * HoudiniAsset, HAPI_A
 	if (HoudiniRuntimeSettings)
 		bMemoryCopyFirst = HoudiniRuntimeSettings->bPreferHdaMemoryCopyOverHdaSourceFile;
 
-	// Get the HDA's file path
+	// Get the HDA's file path, using the AssetImportData if we have it
+	FString AssetFileName = (HoudiniAsset->AssetImportData != nullptr) ? HoudiniAsset->AssetImportData->GetFirstFilename() : HoudiniAsset->GetAssetFileName();
 	// We need to convert relative file path to absolute
-	FString AssetFileName = HoudiniAsset->GetAssetFileName();
 	if (FPaths::IsRelative(AssetFileName))
 		AssetFileName = FPaths::ConvertRelativePathToFull(AssetFileName);
 

--- a/Source/HoudiniEngineEditor/Private/HoudiniAssetFactory.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniAssetFactory.cpp
@@ -86,7 +86,6 @@ UHoudiniAssetFactory::FactoryCreateBinary(
 
 	// Create a new asset.
 	UHoudiniAsset * HoudiniAsset = NewObject< UHoudiniAsset >(InParent, InName, Flags);
-	HoudiniAsset->CreateAsset(Buffer, BufferEnd, UFactory::GetCurrentFilename());
 
 	// Create reimport information.
 	UAssetImportData * AssetImportData = HoudiniAsset->AssetImportData;
@@ -97,6 +96,9 @@ UHoudiniAssetFactory::FactoryCreateBinary(
 	}
 
 	AssetImportData->Update(UFactory::GetCurrentFilename());
+
+	// import with the sanitized filename from the AssetImportData
+	HoudiniAsset->CreateAsset(Buffer, BufferEnd, AssetImportData->GetSourceData().SourceFiles[0].RelativeFilename);
 
 	// Broadcast notification that the new asset has been imported.
 	GEditor->GetEditorSubsystem<UImportSubsystem>()->BroadcastAssetPostImport(this, HoudiniAsset);


### PR DESCRIPTION
This fixes issues when two developers are working on the same HDA asset and have their repositories at different paths. Sanitised paths are now properly used via the AssetImportData, so that the correct Absolute path can be created for the local workspace.

Note: this was reported in support ticket 118871.