### PR TITLE
Fix unneeded cast causing waring/error on Linux

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/UnrealObjectInputRuntimeTypes.cpp
+++ b/Source/HoudiniEngineRuntime/Private/UnrealObjectInputRuntimeTypes.cpp
@@ -422,7 +422,7 @@ FUnrealObjectInputNode::AddRef() const
 	if (!IsRefCounted())
 		return false;
 	
-	static_cast<uint32>(FPlatformAtomics::InterlockedIncrement(&ReferenceCount));
+	FPlatformAtomics::InterlockedIncrement(&ReferenceCount);
 	return true;
 }
 
@@ -439,7 +439,7 @@ FUnrealObjectInputNode::RemoveRef() const
 	}
 #endif
 
-	static_cast<uint32>(FPlatformAtomics::InterlockedDecrement(&ReferenceCount));
+	FPlatformAtomics::InterlockedDecrement(&ReferenceCount);
 	return true;
 }
 


### PR DESCRIPTION
Compiling with latest UE Linux toolchain creates warnings for this typecast, which is treated as error.