### PR TITLE
Fix non unity build + Fix expression result unused

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/UnrealObjectInputRuntimeTypes.cpp
+++ b/Source/HoudiniEngineRuntime/Private/UnrealObjectInputRuntimeTypes.cpp
@@ -25,7 +25,7 @@
 */
 
 #include "UnrealObjectInputRuntimeTypes.h"
-
+#include "HoudiniEngineRuntimePrivatePCH.h"
 #include "CoreMinimal.h"
 #include "UObject/Package.h"
 #include "Templates/Casts.h"
@@ -422,7 +422,7 @@ FUnrealObjectInputNode::AddRef() const
 	if (!IsRefCounted())
 		return false;
 	
-	static_cast<uint32>(FPlatformAtomics::InterlockedIncrement(&ReferenceCount));
+	FPlatformAtomics::InterlockedIncrement(&ReferenceCount);
 	return true;
 }
 
@@ -439,7 +439,7 @@ FUnrealObjectInputNode::RemoveRef() const
 	}
 #endif
 
-	static_cast<uint32>(FPlatformAtomics::InterlockedDecrement(&ReferenceCount));
+	FPlatformAtomics::InterlockedDecrement(&ReferenceCount);
 	return true;
 }
 


### PR DESCRIPTION
We had some errors in our build system after I integrate the latest version.  Non-Unity build and LinuxServer were failing