### PR TITLE
Fix compilation error when building for Android platform with clang 14.0

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniStaticMesh.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniStaticMesh.cpp
@@ -305,9 +305,9 @@ void UHoudiniStaticMesh::CalculateNormals(bool bInComputeWeightedNormals)
 		Area /= 2.0f;
 
 		const float Weight[3] = {
-			bInComputeWeightedNormals ? Area * TriangleUtilities::ComputeTriangleCornerAngle((FVector)V0, (FVector)V1, (FVector)V2) : 1.0f,
-			bInComputeWeightedNormals ? Area * TriangleUtilities::ComputeTriangleCornerAngle((FVector)V1, (FVector)V2, (FVector)V0) : 1.0f,
-			bInComputeWeightedNormals ? Area * TriangleUtilities::ComputeTriangleCornerAngle((FVector)V2, (FVector)V0, (FVector)V1) : 1.0f,
+			static_cast<float>(bInComputeWeightedNormals ? Area * TriangleUtilities::ComputeTriangleCornerAngle((FVector)V0, (FVector)V1, (FVector)V2) : 1.0f),
+			static_cast<float>(bInComputeWeightedNormals ? Area * TriangleUtilities::ComputeTriangleCornerAngle((FVector)V1, (FVector)V2, (FVector)V0) : 1.0f),
+			static_cast<float>(bInComputeWeightedNormals ? Area * TriangleUtilities::ComputeTriangleCornerAngle((FVector)V2, (FVector)V0, (FVector)V1) : 1.0f),
 		};
 
 		for (int CornerIndex = 0; CornerIndex < 3; ++CornerIndex)


### PR DESCRIPTION
```
error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
```