### PR TITLE
Fixed an issue that occurred when the data table had only one row.

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniInputTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniInputTranslator.cpp
@@ -4023,9 +4023,6 @@ FHoudiniInputTranslator::HapiCreateInputNodeForDataTable(const FString& InNodeNa
 	TArray<FString> ColTitles = DataTable->GetUniqueColumnTitles();
 	TArray<FString> NiceNames = DataTable->GetColumnTitles();
 
-	if (RowNames.Num() <= 1)
-		return true;
-
 	int32 NumRows = RowNames.Num();
 	int32 NumAttributes = ColTitles.Num();
 	if (NumRows <= 0 || NumAttributes <= 0)


### PR DESCRIPTION
Fixed an issue that the input node could not be created properly if the datatable-input had only one row.

As I'm guessing, it looks like the code used to check if there is valid data besides the heading row, using UDataTable::GetTableData() as a way in the past.