### PR TITLE
Fix JSON incompatible `HoudiniEngine.uplugin` file.

### DIFF
--- a/HoudiniEngine.uplugin
+++ b/HoudiniEngine.uplugin
@@ -28,7 +28,7 @@
 			"Name" : "HoudiniEngineRuntime",
 			"Type" : "Runtime",
 			"LoadingPhase" : "Default"
-		},
+		}
 	],
 
 	"CanContainContent" : true,


### PR DESCRIPTION
The `HoudiniEngine.uplugin` file has an extra comma that makes it incompatible with many JSON parsers, e.g. CPython.