### PR TITLE
Disable Static Analysis for UE modules

### DIFF
--- a/Source/HoudiniEngine/HoudiniEngine.Build.cs
+++ b/Source/HoudiniEngine/HoudiniEngine.Build.cs
@@ -232,6 +232,10 @@ public class HoudiniEngine : ModuleRules
         PCHUsage = PCHUsageMode.NoSharedPCHs;
         PrivatePCHHeaderFile = "Private/HoudiniEnginePrivatePCH.h";
 
+#if UE_5_2_OR_LATER
+		bDisableStaticAnalysis = true;
+#endif
+
         // Check if we are compiling on unsupported platforms.
         if ( Target.Platform != UnrealTargetPlatform.Win64 &&
             Target.Platform != UnrealTargetPlatform.Mac &&

--- a/Source/HoudiniEngineEditor/HoudiniEngineEditor.Build.cs
+++ b/Source/HoudiniEngineEditor/HoudiniEngineEditor.Build.cs
@@ -36,6 +36,10 @@ public class HoudiniEngineEditor : ModuleRules
         PCHUsage = PCHUsageMode.NoSharedPCHs;
         PrivatePCHHeaderFile = "Private/HoudiniEngineEditorPrivatePCH.h";
 
+#if UE_5_2_OR_LATER
+		bDisableStaticAnalysis = true;
+#endif
+
         // Check if we are compiling on unsupported platforms.
         if ( Target.Platform != UnrealTargetPlatform.Win64 &&
             Target.Platform != UnrealTargetPlatform.Mac &&

--- a/Source/HoudiniEngineRuntime/HoudiniEngineRuntime.Build.cs
+++ b/Source/HoudiniEngineRuntime/HoudiniEngineRuntime.Build.cs
@@ -38,6 +38,10 @@ public class HoudiniEngineRuntime : ModuleRules
         PrivatePCHHeaderFile = "Private/HoudiniEngineRuntimePrivatePCH.h";
 		PrecompileForTargets = PrecompileTargetsType.Any;
 
+#if UE_5_2_OR_LATER
+		bDisableStaticAnalysis = true;
+#endif
+
 		// Check if we are compiling for unsupported platforms.
 		if ( Target.Platform != UnrealTargetPlatform.Win64 &&
 			Target.Platform != UnrealTargetPlatform.Mac &&


### PR DESCRIPTION
Currently, when Static Analysis is run on a project, it reports issues for Houdini - which is not actionable for the project.

This PR disables SA for Houdini modules to keep output logs clean.