### PR TITLE
Update includes for compilation as an engine plugin for UE 5.2 

### DIFF
--- a/Source/HoudiniEngine/HoudiniEngine.Build.cs
+++ b/Source/HoudiniEngine/HoudiniEngine.Build.cs
@@ -232,6 +232,8 @@ public class HoudiniEngine : ModuleRules
         PCHUsage = PCHUsageMode.NoSharedPCHs;
         PrivatePCHHeaderFile = "Private/HoudiniEnginePrivatePCH.h";
 
+        // bUseUnity = false;  // enable when testing includes
+
         // Check if we are compiling on unsupported platforms.
         if ( Target.Platform != UnrealTargetPlatform.Win64 &&
             Target.Platform != UnrealTargetPlatform.Mac &&

--- a/Source/HoudiniEngine/Private/HBSPOps.cpp
+++ b/Source/HoudiniEngine/Private/HBSPOps.cpp
@@ -32,6 +32,7 @@
 #include "Editor/EditorEngine.h"
 #include "Components/BrushComponent.h"
 #include "GameFramework/Volume.h"
+#include "MaterialDomain.h"  //MF: for MD_Surface
 
 DEFINE_LOG_CATEGORY_STATIC(LogBSPOps, Log, All);
 

--- a/Source/HoudiniEngine/Private/HCsgUtils.cpp
+++ b/Source/HoudiniEngine/Private/HCsgUtils.cpp
@@ -34,6 +34,7 @@
 
 #include "ActorEditorUtils.h"
 #include "Misc/ScopedSlowTask.h"
+#include "MaterialDomain.h"  // MF: for MD_Surface
 
 
 DEFINE_LOG_CATEGORY_STATIC(LogHCsgUtils, Log, All);

--- a/Source/HoudiniEngine/Private/HoudiniEngine.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniEngine.cpp
@@ -50,6 +50,7 @@
 #include "HAL/PlatformFileManager.h"
 #include "Async/Async.h"
 #include "Logging/LogMacros.h"
+#include "Framework/Application/SlateApplication.h"  // MF: For FSlateApplication
 
 #if WITH_EDITOR
 	#include "Widgets/Notifications/SNotificationList.h"

--- a/Source/HoudiniEngine/Private/HoudiniEngineTimers.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniEngineTimers.cpp
@@ -28,6 +28,7 @@
 #include "HoudiniEngine.h"
 #include "HoudiniEngineRuntimePrivatePCH.h"
 #include "HoudiniEngineTimers.h"
+#include "HAL/IConsoleManager.h"
 
 int thread_local FHoudiniEngineScopedTimer::CurrentDepth = 0;
 

--- a/Source/HoudiniEngine/Private/HoudiniEngineUtils.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniEngineUtils.cpp
@@ -79,6 +79,7 @@
 #include "RawMesh.h"
 #include "Widgets/Notifications/SNotificationList.h"
 #include "Framework/Notifications/NotificationManager.h"
+#include "Framework/Application/SlateApplication.h"  // MF: For FSlateApplication
 #include "Interfaces/IPluginManager.h"
 //#include "Kismet/BlueprintEditor.h"
 #include "SSCSEditor.h"

--- a/Source/HoudiniEngine/Private/HoudiniGeometryCollectionTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniGeometryCollectionTranslator.cpp
@@ -12,6 +12,8 @@
 #include "GeometryCollection/GeometryCollectionComponent.h"
 #include "GeometryCollection/GeometryCollectionObject.h"
 #include "GeometryCollection/GeometryCollectionActor.h"
+#include "GeometryCollection/GeometryCollection.h"  // MF: For #include FGeometryCollection
+#include "MaterialDomain.h"  // MF: For MD_Surface
 #include "Materials/Material.h"
 
 void

--- a/Source/HoudiniEngine/Private/HoudiniInputTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniInputTranslator.cpp
@@ -77,6 +77,7 @@
 #include "UnrealGeometryCollectionTranslator.h"
 
 #include "Async/Async.h"
+#include "GeometryCollection/GeometryCollection.h"  // MF: For #include FGeometryCollection
 #include "GeometryCollectionEngine/Public/GeometryCollection/GeometryCollectionActor.h"
 #include "GeometryCollectionEngine/Public/GeometryCollection/GeometryCollectionComponent.h"
 #include "GeometryCollectionEngine/Public/GeometryCollection/GeometryCollectionObject.h"

--- a/Source/HoudiniEngine/Private/HoudiniMaterialTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniMaterialTranslator.cpp
@@ -53,6 +53,8 @@
 #include "PackageTools.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "UObject/MetaData.h"
+#include "MaterialShared.h"  // MF: for FMaterialUpdateContext
+#include "Engine/Texture2D.h"  // MF: for UTexture2D
 
 #if WITH_EDITOR
 	#include "Factories/MaterialFactoryNew.h"

--- a/Source/HoudiniEngine/Private/HoudiniMeshTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniMeshTranslator.cpp
@@ -75,6 +75,7 @@
 #include "ImportUtils/SkeletalMeshImportUtils.h"
 #include "Math/UnrealMathUtility.h"
 #include "PhysicalMaterials/PhysicalMaterial.h"
+#include "Engine/SkinnedAssetCommon.h"  // MF: For FSkeletalMaterial
 
 #if WITH_EDITOR
 	#include "ConvexDecompTool.h"

--- a/Source/HoudiniEngine/Private/UnrealGeometryCollectionTranslator.cpp
+++ b/Source/HoudiniEngine/Private/UnrealGeometryCollectionTranslator.cpp
@@ -37,10 +37,12 @@
 #include "Engine/SkeletalMesh.h"
 
 #include "GeometryCollection/GeometryCollectionClusteringUtility.h"
+#include "GeometryCollection/GeometryCollection.h"  // MF: For UGeometryCollectio
 #include "GeometryCollectionEngine/Public/GeometryCollection/GeometryCollectionComponent.h"
 #include "GeometryCollectionEngine/Public/GeometryCollection/GeometryCollectionObject.h"
 #include "GeometryCollectionEngine/Public/GeometryCollection/GeometryCollectionActor.h"
 #include "Materials/Material.h"
+#include "MaterialDomain.h"  // MF: For MD_Surface
 
 bool 
 FUnrealGeometryCollectionTranslator::HapiCreateInputNodeForGeometryCollection(

--- a/Source/HoudiniEngine/Private/UnrealInstanceTranslator.cpp
+++ b/Source/HoudiniEngine/Private/UnrealInstanceTranslator.cpp
@@ -34,6 +34,7 @@
 
 #include "Engine/StaticMesh.h"
 #include "Components/InstancedStaticMeshComponent.h"
+#include "Materials/MaterialInterface.h"  // MF: For UMaterialInterface
 
 bool
 FUnrealInstanceTranslator::HapiCreateInputNodeForInstancer(

--- a/Source/HoudiniEngine/Private/UnrealMeshTranslator.cpp
+++ b/Source/HoudiniEngine/Private/UnrealMeshTranslator.cpp
@@ -47,6 +47,9 @@
 #include "HoudiniEngineTimers.h"
 #include "Rendering/SkeletalMeshModel.h"
 #include "MeshUtilities.h"
+#include "MaterialDomain.h"  // MF: For MD_Surface
+#include "Engine/SkinnedAssetCommon.h"  // MF: For FSkeletalMaterial
+#include "StaticMeshResources.h"  // MF: For FStaticMeshRenderData
 #include <locale> 
 #include <codecvt>
 

--- a/Source/HoudiniEngineEditor/HoudiniEngineEditor.Build.cs
+++ b/Source/HoudiniEngineEditor/HoudiniEngineEditor.Build.cs
@@ -36,6 +36,8 @@ public class HoudiniEngineEditor : ModuleRules
         PCHUsage = PCHUsageMode.NoSharedPCHs;
         PrivatePCHHeaderFile = "Private/HoudiniEngineEditorPrivatePCH.h";
 
+        // bUseUnity = false;  // enable when testing includes
+
         // Check if we are compiling on unsupported platforms.
         if ( Target.Platform != UnrealTargetPlatform.Win64 &&
             Target.Platform != UnrealTargetPlatform.Mac &&

--- a/Source/HoudiniEngineEditor/Private/AssetTypeActions_HoudiniAsset.cpp
+++ b/Source/HoudiniEngineEditor/Private/AssetTypeActions_HoudiniAsset.cpp
@@ -41,6 +41,7 @@
 #include "EditorFramework/AssetImportData.h"
 #include "LevelEditor.h"
 #include "Modules/ModuleManager.h"
+#include "UObject/UObjectIterator.h"  // MF: For TObjectIterator
 
 #include "Internationalization/Internationalization.h"
 

--- a/Source/HoudiniEngineEditor/Private/HoudiniEditorSubsystem.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEditorSubsystem.cpp
@@ -18,6 +18,7 @@
 
 #include "Engine/SkeletalMesh.h"
 //#include "Toolkits/AssetEditorModeUILayer.h"
+#include "Engine/SkinnedAssetCommon.h"  // MF: For FSkeletalMaterial
 
 
 

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.cpp
@@ -109,6 +109,8 @@
 #include "WorldPartition/WorldPartitionSubsystem.h"
 #include "Kismet2/ComponentEditorUtils.h"
 #include "Animation/SkeletalMeshActor.h"
+#include "Engine/SkinnedAssetCommon.h"  // MF: For FSkeletalMaterial
+#include "Materials/MaterialExpressionTextureSample.h"  // MF: For UMaterialExpressionTextureSample
 
 #include "GeometryCollectionEngine/Public/GeometryCollection/GeometryCollectionComponent.h"
 #include "GeometryCollectionEngine/Public/GeometryCollection/GeometryCollectionObject.h"

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.h
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.h
@@ -29,6 +29,7 @@
 #include "HoudiniPDGAssetLink.h"
 #include "HoudiniOutput.h"
 #include "HoudiniPackageParams.h"
+#include "Materials/MaterialExpression.h"  // MF: for UMaterialExpression
 
 class UHoudiniAssetComponent;
 class UHoudiniOutput;

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineCommands.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineCommands.cpp
@@ -59,6 +59,7 @@
 #include "ISettingsModule.h"
 #include "UObject/ObjectSaveContext.h"
 //#include "UObject/ObjectSaveContext.h"
+#include "UObject/UObjectIterator.h"  // MF: For TObjectIterator
 
 #define LOCTEXT_NAMESPACE HOUDINI_LOCTEXT_NAMESPACE 
 

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineEditorPrivatePCH.h
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineEditorPrivatePCH.h
@@ -31,6 +31,7 @@
 #include "HoudiniEngineRuntimePrivatePCH.h"
 
 #include "Editor.h"
+#include "Runtime/Launch/Resources/Version.h" // MF; get ENGINE_MINOR_VERSION
 
 // Details panel desired sizes.
 #define HAPI_UNREAL_DESIRED_ROW_VALUE_WIDGET_WIDTH              270

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineEditorUtils.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineEditorUtils.cpp
@@ -46,6 +46,8 @@
 #include "FileHelpers.h"
 #include "PropertyPathHelpers.h"
 #include "Components/SceneComponent.h"
+#include "UObject/UObjectIterator.h"  // MF: For TObjectIterator
+#include "Materials/MaterialInterface.h"  // MF: For UMaterialInterface
 
 #define LOCTEXT_NAMESPACE HOUDINI_LOCTEXT_NAMESPACE 
 

--- a/Source/HoudiniEngineEditor/Private/HoudiniHandleComponentVisualizer.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniHandleComponentVisualizer.cpp
@@ -28,6 +28,7 @@
 
 #include "EditorViewportClient.h"
 #include "CanvasTypes.h"
+#include "SceneView.h"  // MF: For FSceneView
 
 #include "HoudiniEngineEditorPrivatePCH.h"
 #include "HoudiniHandleTranslator.h"

--- a/Source/HoudiniEngineEditor/Private/HoudiniSplineComponentVisualizer.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniSplineComponentVisualizer.cpp
@@ -46,6 +46,8 @@
 #include "EditorViewportClient.h"
 #include "Engine/Selection.h"
 #include "HModel.h"
+#include "SceneView.h"  // MF: For FSceneView
+#include "Framework/Application/SlateApplication.h"  // MF: For FSlateApplication
 
 #define LOCTEXT_NAMESPACE HOUDINI_LOCTEXT_NAMESPACE 
 

--- a/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestUtils.cpp
+++ b/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestUtils.cpp
@@ -60,6 +60,8 @@
 #include "Interfaces/IMainFrameModule.h"
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationCommon.h"
+#include "Framework/Application/SlateApplication.h"  // MF: For FSlateApplication
+#include "PropertyEditorModule.h" // MF: For FPropertyEditorModule
 
 const FVector2D FHoudiniEditorTestUtils::GDefaultEditorSize = FVector2D(1280, 720);
 const FString FHoudiniEditorTestUtils::SavedPathFolder = "/Game/TestSaved/";

--- a/Source/HoudiniEngineRuntime/HoudiniEngineRuntime.Build.cs
+++ b/Source/HoudiniEngineRuntime/HoudiniEngineRuntime.Build.cs
@@ -38,6 +38,8 @@ public class HoudiniEngineRuntime : ModuleRules
         PrivatePCHHeaderFile = "Private/HoudiniEngineRuntimePrivatePCH.h";
 		PrecompileForTargets = PrecompileTargetsType.Any;
 
+        // bUseUnity = false;  // enable when testing includes
+
 		// Check if we are compiling for unsupported platforms.
 		if ( Target.Platform != UnrealTargetPlatform.Win64 &&
 			Target.Platform != UnrealTargetPlatform.Mac &&

--- a/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.cpp
@@ -55,6 +55,7 @@
 #include "BodySetupEnums.h"
 #include "PhysicalMaterials/PhysicalMaterial.h"
 #include "GeometryCollectionEngine/Public/GeometryCollection/GeometryCollectionComponent.h"
+#include "PrimitiveSceneProxy.h"  // MF: For FPrimitiveSceneProxy
 
 #if WITH_EDITOR
 	#include "Editor/UnrealEd/Private/GeomFitUtils.h"

--- a/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.h
@@ -39,6 +39,7 @@
 #include "IHoudiniAssetStateEvents.h"
 
 #include "Engine/EngineTypes.h"
+#include "Engine/SimpleConstructionScript.h"
 #include "Components/PrimitiveComponent.h"
 #include "Components/SceneComponent.h"
 

--- a/Source/HoudiniEngineRuntime/Private/HoudiniEngineRuntimePrivatePCH.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniEngineRuntimePrivatePCH.h
@@ -28,6 +28,7 @@
 
 #include "CoreMinimal.h"
 #include "Logging/LogMacros.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 // Define module names.
 #define HOUDINI_MODULE "HoudiniEngine"

--- a/Source/HoudiniEngineRuntime/Private/HoudiniInputObject.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniInputObject.cpp
@@ -50,6 +50,7 @@
 #include "FoliageType_InstancedStaticMesh.h"
 #include "Engine/SimpleConstructionScript.h"
 #include "Engine/SCS_Node.h"
+#include "Engine/SkinnedAssetCommon.h"  // MF: For FSkeletalMaterial
 
 #include "Model.h"
 #include "Engine/Brush.h"

--- a/Source/HoudiniEngineRuntime/Private/HoudiniPDGAssetLink.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniPDGAssetLink.cpp
@@ -32,6 +32,7 @@
 #include "HoudiniOutput.h"
 
 #include "Engine/StaticMesh.h"
+#include "Engine/Level.h"
 #include "GameFramework/Actor.h"
 #include "Landscape.h"
 #include "UObject/MetaData.h"

--- a/Source/HoudiniEngineRuntime/Private/HoudiniStaticMeshComponent.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniStaticMeshComponent.cpp
@@ -28,6 +28,8 @@
 
 #include "Components/BillboardComponent.h"
 #include "Engine/CollisionProfile.h"
+#include "SceneInterface.h"  // MF: For FSceneInterface
+#include "Engine/Texture2D.h"  // MF: For UTextureD2
 
 #include "HoudiniStaticMesh.h"
 #include "HoudiniStaticMeshSceneProxy.h"

--- a/Source/HoudiniEngineRuntime/Private/HoudiniStaticMeshSceneProxy.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniStaticMeshSceneProxy.cpp
@@ -30,6 +30,9 @@
 #include "Materials/Material.h"
 #include "PrimitiveViewRelevance.h"
 #include "Engine/Engine.h"
+#include "MaterialDomain.h"  // MF: for MD_Surface
+#include "Materials/MaterialRenderProxy.h"  // MF: For FColoredMaterialRenderProxy
+#include "SceneInterface.h" // MF: For FSceneInterface
 
 #include "ProfilingDebugging/CpuProfilerTrace.h"
 


### PR DESCRIPTION
Also, make sure it compiles with "unity build" disabled.
This has only been tested agains the `5.2-release` branch from epic's repo.  Possibly some of these included need to have
`#ifdef ENGINE_MINOR_VERSION >= 2` added for 5.0 or 5.1