### PR TITLE
Fix incorrect use of conversion macros, caught by Linux build (clang)

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniDataTableTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniDataTableTranslator.cpp
@@ -1051,7 +1051,8 @@ FHoudiniDataTableTranslator::PopulateRowData(int32 GeoId,
 	for (auto&& KV : FoundProps)
 	{
 		HAPI_Result Result = HAPI_RESULT_FAILURE;
-		ANSICHAR* AttribName = TCHAR_TO_ANSI(*KV.Key);
+		auto Src = StringCast<ANSICHAR>(*KV.Key);
+		const ANSICHAR* AttribName = Src.Get();
 		FProperty* Prop = KV.Value;
 		int32 Offset = Prop->GetOffset_ForInternal();
 

--- a/Source/HoudiniEngine/Private/UnrealMeshTranslator.cpp
+++ b/Source/HoudiniEngine/Private/UnrealMeshTranslator.cpp
@@ -4874,12 +4874,11 @@ FUnrealMeshTranslator::CreateInputNodeForCollider(
 	const TArray<int32>& ColliderIndices)
 {
 	// Create a new input node for the collider
-	const char * ColliderNameStr = TCHAR_TO_UTF8(*ColliderName);
 
 	// Create the node in this input object's OBJ node
 	HAPI_NodeId ColliderNodeId = -1;
 	HOUDINI_CHECK_ERROR_RETURN( FHoudiniEngineUtils::CreateNode(
-		InParentNodeID, "null", ColliderNameStr, false, &ColliderNodeId), false);
+		InParentNodeID, "null", TCHAR_TO_UTF8(*ColliderName), false, &ColliderNodeId), false);
 
 	// Create a part
 	HAPI_PartInfo Part;


### PR DESCRIPTION
The `TCHAR_TO_ANSI` style macros _must not_ be used like this.  They can only be used directly for arguments to function calls, etc.
To assign a pointer to the converted value, an intermediate conversion variable must be used.

Found by cross-compiling for Linux using Clang