### PR TITLE
Fix crash Update HoudiniAssetBlueprintComponent.cpp

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniAssetBlueprintComponent.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniAssetBlueprintComponent.cpp
@@ -231,7 +231,7 @@ UHoudiniAssetBlueprintComponent::CopyStateToTemplateComponent()
 			// outputs are only currently used for world partition, which don't make sense for use in blueprints.
 
 			USceneComponent* ComponentTemplate = nullptr;
-			if (InstanceObj.OutputComponents.Num() == 1)
+			if (TemplateObj.OutputComponents.Num() == 1)
 			{
 				ComponentTemplate = Cast<USceneComponent>(TemplateObj.OutputComponents[0]);
 			}


### PR DESCRIPTION
Fix crash when adding a HoudiniAssetBlueprintComponent to BP. Copy/Paste error. Fix for issue 233