### PR TITLE
Fix compilation on macOS caused by EFoliageAttachmentType enum shadowing variables in global space

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniFoliageTools.h
+++ b/Source/HoudiniEngine/Private/HoudiniFoliageTools.h
@@ -39,7 +39,7 @@ class UStaticMesh;
 class USceneComponent;
 class UFoliageType;
 
-enum EFoliageAttachmentType
+enum class EFoliageAttachmentType
 {
 	None = 0,
 	All = 1,


### PR DESCRIPTION
The enum shadows other enums from UE with the same constants. Making it an enum class
prevents the leakage of unqualified constants into the global space.

Compiler error: declaration shadows a variable in the global namespace [-Werror,-Wshadow]