### PR TITLE
Fix for unreal spline output rotations being incorrect

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniSplineTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniSplineTranslator.cpp
@@ -1638,9 +1638,11 @@ FHoudiniSplineTranslator::CreateOutputUnrealSplineComponent(
 	NewSplineComponent->ClearSplinePoints();
 	NewSplineComponent->bEditableWhenInherited = false;
  
+ 	ESplinePointType::Type SplinePointType = bIsLinear ? ESplinePointType::Linear : ESplinePointType::Curve;
 	for (int32 n = 0; n < CurvePoints.Num(); ++n) 
 	{
 		NewSplineComponent->AddSplinePoint(CurvePoints[n], ESplineCoordinateSpace::Local);
+		NewSplineComponent->SetSplinePointType(n, SplinePointType);
 	}
 
 	bool bHasScales = CurveScales.Num() == CurvePoints.Num();
@@ -1657,21 +1659,9 @@ FHoudiniSplineTranslator::CreateOutputUnrealSplineComponent(
 	{
 		for (int32 n = 0; n < CurvePoints.Num(); ++n)
 		{
-			NewSplineComponent->SetRotationAtSplinePoint(n, CurveRotations[n].Rotation(), ESplineCoordinateSpace::Local, false);
+			NewSplineComponent->SetRotationAtSplinePoint(n, FRotator::MakeFromEuler(CurveRotations[n]), ESplineCoordinateSpace::Local, false);
 		}
 	}
-
-	if (bIsLinear)
-	{
-		for (int32 n = 0; n < CurvePoints.Num(); ++n)
-			NewSplineComponent->SetSplinePointType(n, ESplinePointType::Linear);
-	}
-	else 
-	{
-		for (int32 n = 0; n < CurvePoints.Num(); ++n)
-			NewSplineComponent->SetSplinePointType(n, ESplinePointType::Curve);
-	}
-
 
 	NewSplineComponent->SetClosedLoop(bIsClosed);
 
@@ -1729,7 +1719,7 @@ FHoudiniSplineTranslator::UpdateOutputUnrealSplineComponent(
 	{
 		for (int32 n = 0; n < CurvePoints.Num(); ++n)
 		{
-			EditedSplineComponent->SetRotationAtSplinePoint(n, CurveRotations[n].Rotation(), ESplineCoordinateSpace::Local, false);
+			EditedSplineComponent->SetRotationAtSplinePoint(n, FRotator::MakeFromEuler(CurveRotations[n]), ESplineCoordinateSpace::Local, false);
 		}
 	}
 


### PR DESCRIPTION
- CurveRotations are euler angles, but to convert them to FRotators, FVector::Rotation() was being used. This calculates an orientation vector for the given rotation, which isn't wanted here. Instead, FRotator::MakeFromEuler is correct
- SetSplinePointType was being called after SetRotationAtSplinePoint. However, SetRotationAtSplinePoint sets the point type to CIM_CurveUser to prevent automatic tangent/rotation calculation. By setting the curve type to linear or curve after SetRotationAtSplinePoint, the rotation set by that function was replaced by an automatically calculated rotation. By setting the point type immediately after calling AddSplinePoint, this issue is prevented