### PR TITLE
Setting the respective Nanite FallbackTarget for given Fallback Values

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniMeshTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniMeshTranslator.cpp
@@ -1650,6 +1650,9 @@ FHoudiniMeshTranslator::UpdateStaticMeshNaniteSettings(const int32& GeoId, const
 
 	if (FloatData.Num() > 0)
 	{
+		// If a nanite percent triangles attribute was found, we propably also want to set the fallback target to PercentTriangles
+		StaticMesh->NaniteSettings.FallbackTarget = ENaniteFallbackTarget::PercentTriangles;
+
 		StaticMesh->NaniteSettings.FallbackPercentTriangles = FMath::Clamp<float>(FloatData[0], 0.0f, 1.0f);
 	}
 
@@ -1670,6 +1673,9 @@ FHoudiniMeshTranslator::UpdateStaticMeshNaniteSettings(const int32& GeoId, const
 
 	if (FloatData.Num() > 0)
 	{
+		// If a fb relative error attribute was found, we propably also want to set the fallback target to RelativeError
+		StaticMesh->NaniteSettings.FallbackTarget = ENaniteFallbackTarget::RelativeError;
+
 		StaticMesh->NaniteSettings.FallbackRelativeError = FMath::Clamp<float>(FloatData[0], 0.0f, 1.0f);
 	}
 


### PR DESCRIPTION
When I use either "unreal_nanite_percent_triangles" or "unreal_nanite_fallback_relative_error" to specify the parameters for the Nanite fallback mesh - in my case to give the collision a higher resolution - those values are still ignored in unreal because the FallbackTarget remains on "Auto".
I guess it's safe to asssume, that if one of the two attributes is set, that it is desired to use the apropriate method as the FallbackTarget as well.