### PR TITLE
Fix compilation errors on 5.2

### DIFF
--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.cpp
@@ -155,6 +155,9 @@
 #include "HoudiniFoliageUtils.h"
 
 
+// mainframe fpr 5.2
+#include "SkeletalMeshTypes.h"
+
 HOUDINI_BAKING_DEFINE_LOG_CATEGORY();
 
 #define LOCTEXT_NAMESPACE HOUDINI_LOCTEXT_NAMESPACE

--- a/Source/HoudiniEngineEditor/Private/HoudiniToolsEditor.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniToolsEditor.cpp
@@ -81,9 +81,13 @@
 	#include "EditorAssetLibrary.h"
 #endif
 
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
+// mf for 5.2
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 	#include "TextureResource.h"
 #endif
+
+// mf for 5.2
+#include "Engine/Texture2D.h"
 
 #ifdef LOCTEXT_NAMESPACE
 // This undef is here to get rid of the definition from UE's DecoratedDragDropOp.h.


### PR DESCRIPTION
There were missing includes.
As always, I recommend building regularly with `bUseUnity = false;` in the `build.cs` files to weed out missing includes.