### PR TITLE
Add support for getting baked output actors from Wrapper

### DIFF
--- a/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIAssetWrapper.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIAssetWrapper.cpp
@@ -437,6 +437,28 @@ UHoudiniPublicAPIAssetWrapper::GetReplacePreviousBake_Implementation() const
 	return HAC->bReplacePreviousBake;
 }
 
+TArray<AActor*> UHoudiniPublicAPIAssetWrapper::GetBakedOutputActors_Implementation() {
+
+    TArray<AActor*> OutputActors;
+	UHoudiniAssetComponent* HAC = nullptr;
+    if (!GetValidHoudiniAssetComponentWithError(HAC)) {
+		return OutputActors;
+	}
+
+    const TArray<FHoudiniBakedOutput>& BakedOutputs = HAC->GetBakedOutputs();
+
+    for (const FHoudiniBakedOutput& BakedOutput : BakedOutputs) {
+        for (const auto& BakedPair : BakedOutput.BakedOutputObjects) {
+            AActor* Actor = BakedPair.Value.GetActorIfValid(true);
+            if (Actor) {
+                OutputActors.Add(Actor);
+            }
+        }
+    }
+
+    return OutputActors;
+}
+
 bool
 UHoudiniPublicAPIAssetWrapper::GetValidHoudiniAssetActorWithError(AHoudiniAssetActor*& OutActor) const
 {

--- a/Source/HoudiniEngineEditor/Public/HoudiniPublicAPIAssetWrapper.h
+++ b/Source/HoudiniEngineEditor/Public/HoudiniPublicAPIAssetWrapper.h
@@ -562,6 +562,14 @@ public:
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category="Houdini|Public API")
 	bool GetReplacePreviousBake() const;
 
+	/**
+	 * Gets all generated Actors which are the result of a bake.
+	 * @return array of scene actors from bake action.
+	*/
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category="Houdini|Public API")
+	TArray<AActor*> GetBakedOutputActors();
+
+
 	// Parameters
 
 	/**


### PR DESCRIPTION
This adds GetBakedOutputActors() to the AssetWrapper, so you can get a direct reference to the generated actors in a scene.
This is extremely useful for doing any sort of post processing on generated actors. Eg setting uproperties, or doing other things not supported by the plugin.