### PR TITLE
Improve responsiveness of cooking

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniEngineScheduler.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniEngineScheduler.cpp
@@ -527,7 +527,7 @@ FHoudiniEngineScheduler::ProcessQueuedTasks()
 		if (FPlatformProcess::SupportsMultithreading())
 		{
 			// We want to yield for a bit.
-			FPlatformProcess::SleepNoStats(UpdateFrequency);
+			WakeUpEvent->Wait(UpdateFrequency * 1000);
 		}
 		else
 		{
@@ -649,6 +649,9 @@ FHoudiniEngineScheduler::AddTask(const FHoudiniEngineTask & Task)
 
 	// Wrap around if required.
 	PositionWrite &= (TaskCount - 1);
+
+	// Wake up thread to handle task.
+	WakeUpEvent->Trigger();
 }
 
 uint32

--- a/Source/HoudiniEngine/Private/HoudiniEngineScheduler.h
+++ b/Source/HoudiniEngine/Private/HoudiniEngineScheduler.h
@@ -28,6 +28,7 @@
 
 #include "HoudiniEngineTask.h"
 #include "HoudiniEngineTaskInfo.h"
+#include "HAL/Event.h"
 #include "HAL/Runnable.h"
 #include "HAL/RunnableThread.h"
 #include "Misc/SingleThreadRunnable.h"
@@ -101,6 +102,9 @@ private:
 
 	// Synchronization primitive. 
 	FCriticalSection CriticalSection;
+
+	// Event to wake up thread when tasks become available. 
+	FEventRef WakeUpEvent = FEventRef(EEventMode::AutoReset);
 
 	// List of scheduled tasks. 
 	FHoudiniEngineTask* Tasks;


### PR DESCRIPTION
# Problem

There is a large latency added to cooking due to how tasks are handed off between threads.

When a cook needs to occur, the main thread enqueues a task for the HoudiniSchedulerThread to execute the cook. (See: FHoudiniEngineManager::StartTaskAssetCooking)

The HoudiniSchedulerThread discovers a new task is available by polling the task queue. (See: FHoudiniEngineScheduler::ProcessQueuedTasks)

The thread only polls the task queue every 100ms. This incurs a random 0ms to 100ms to latency in processing the request. (See: FHoudiniEngineScheduler::UpdateFrequency)

# Solution

This PR introduces an FEventRef into the FHoudiniEngineScheduler. The FEventRef is used to wake up the HoudiniSchedulerThread immediately when work becomes available.

This change eliminates any latency caused by the polling. This improves the responsiveness of cooks by on average 50ms.

# Unreal Insights Example

Here is a illustration of the problem using Unreal Insights. (My images may look different than yours as I have a number of additional profiling scopes added.)

You can see there is a large delay between FHoudiniEngineManager::ProcessComponents adding the task and the HoudiniSchedulerThread handling the task.
![image](https://github.com/sideeffects/HoudiniEngineForUnreal/assets/880683/513f30cb-7834-4478-b4a3-544f57ad7a2d)

Here is what it looks like after this change, where the HoudiniSchedulerThread handles the task immediately.
![image](https://github.com/sideeffects/HoudiniEngineForUnreal/assets/880683/4812819a-a36b-4180-9cf3-34eaa7f7b6a6)
