### PR TITLE
Added default constructor initialization for bExportLevelInstanceContent for struct FHoudiniInputObjectSettings

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniInputTypes.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniInputTypes.cpp
@@ -60,6 +60,7 @@ FHoudiniInputObjectSettings::FHoudiniInputObjectSettings()
 	, bExportHeightDataPerEditLayer(true)
 	, bExportPaintLayersPerEditLayer(false)
 	, bExportMergedPaintLayers(true)
+	, bExportLevelInstanceContent(true)
 {
 	UHoudiniRuntimeSettings const* const HoudiniRuntimeSettings = GetDefault<UHoudiniRuntimeSettings>();
 	if (IsValid(HoudiniRuntimeSettings))


### PR DESCRIPTION
### Problem
Uninitialized member variable `bExportLevelInstanceContent` of struct `FHoudiniInputObjectSettings` can cause error log when loading struct/class
`LogClass: Error: BoolProperty FHoudiniInputObjectSettings::bExportLevelInstanceContent is not initialized properly even though its struct probably has a custom default constructor. Module:HoudiniEngineRuntime File:Private/HoudiniInputTypes.h`
### Solution
Added default constructor initialization for `bExportLevelInstanceContent` and set to true by default