### PR TITLE
Add baked foliage actors to obtained outputs

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniFoliageTools.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniFoliageTools.cpp
@@ -181,7 +181,7 @@ TArray<FFoliageInstance> FHoudiniFoliageTools::GetAllFoliageInstances(UWorld* In
     return Results;
 }
 
-void FHoudiniFoliageTools::SpawnFoliageInstances(UWorld* InWorld, UFoliageType* Settings, const TArray<FFoliageInstance>& InstancesToPlace, const TArray<FFoliageAttachmentInfo>& AttachmentInfo)
+TArray<AInstancedFoliageActor*> FHoudiniFoliageTools::SpawnFoliageInstances(UWorld* InWorld, UFoliageType* Settings, const TArray<FFoliageInstance>& InstancesToPlace, const TArray<FFoliageAttachmentInfo>& AttachmentInfo)
 {
 	// This code is largely cribbed from SpawnFoliageInstance() in UE5's FoliageEdMode.cpp. It has UI specific functionality removed.
 
@@ -189,6 +189,7 @@ void FHoudiniFoliageTools::SpawnFoliageInstances(UWorld* InWorld, UFoliageType* 
 	const bool bSpawnInCurrentLevel = true;
 	ULevel* CurrentLevel = InWorld->GetCurrentLevel();
 	const bool bCreate = true;
+	TSet<AInstancedFoliageActor*> FoliageActors;
 	for (int Index = 0; Index < InstancesToPlace.Num(); Index++)
 	{
 		const FFoliageInstance& PlacedInstance = InstancesToPlace[Index];
@@ -196,6 +197,7 @@ void FHoudiniFoliageTools::SpawnFoliageInstances(UWorld* InWorld, UFoliageType* 
 		if (AInstancedFoliageActor* IFA = AInstancedFoliageActor::Get(InWorld, bCreate, LevelHint, PlacedInstance.Location))
 		{
 			PerIFAInstances.FindOrAdd(IFA).Add(Index);
+			FoliageActors.Add(IFA);
 		}
 	}
 
@@ -228,6 +230,8 @@ void FHoudiniFoliageTools::SpawnFoliageInstances(UWorld* InWorld, UFoliageType* 
 		    FoliageInfo->Refresh(true, false);
 		}
 	}
+
+	return FoliageActors.Array();
 }
 
 void

--- a/Source/HoudiniEngine/Private/HoudiniFoliageTools.h
+++ b/Source/HoudiniEngine/Private/HoudiniFoliageTools.h
@@ -68,7 +68,7 @@ public:
 	static TArray<UFoliageType*> GetFoliageTypes(const ULevel* DesiredLevel, const UStaticMesh* InstancedStaticMesh);
 
 	// Spawn the Foliage Instances into the given World/Foliage Type.
-	static void SpawnFoliageInstances(UWorld* InWorld, UFoliageType* Settings, const TArray<FFoliageInstance>& InstancesToPlace, const TArray<FFoliageAttachmentInfo> & AttachementInfos);
+	static TArray<AInstancedFoliageActor*> SpawnFoliageInstances(UWorld* InWorld, UFoliageType* Settings, const TArray<FFoliageInstance>& InstancesToPlace, const TArray<FFoliageAttachmentInfo> & AttachementInfos);
 
 	// Returns Foliage Instances used in the given World by the Foliage Type.
 	static TArray<FFoliageInstance> GetAllFoliageInstances(UWorld* InWorld, UFoliageType* Settings);

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.cpp
@@ -1000,7 +1000,7 @@ FHoudiniEngineBakeUtils::BakeFoliageTypes(
 		// Copy all cooked instances to reference the baked instances.
 		auto Instances = FHoudiniFoliageTools::GetAllFoliageInstances(DesiredWorld, OutputObject->FoliageType);
 
-		FHoudiniFoliageTools::SpawnFoliageInstances(DesiredWorld, TargetFoliageType, Instances, {});
+		TArray<AInstancedFoliageActor*> FoliageActors = FHoudiniFoliageTools::SpawnFoliageInstances(DesiredWorld, TargetFoliageType, Instances, {});
 
 		TArray<FVector> InstancesPositions;
 		InstancesPositions.Reserve(Instances.Num());
@@ -1009,9 +1009,17 @@ FHoudiniEngineBakeUtils::BakeFoliageTypes(
 			InstancesPositions.Add(Instance.Location);	
 		}
 
+		TArray<FString> ActorInstancePaths;
+		ActorInstancePaths.Reserve(FoliageActors.Num());
+		for (auto & Instance : FoliageActors) 
+		{
+			ActorInstancePaths.Add(Instance->GetPathName());
+		}
+
 		// Store back output object.
 		BakedObject.FoliageType = TargetFoliageType;
 		BakedObject.FoliageInstancePositions = InstancesPositions;
+		BakedObject.FoliageActors = ActorInstancePaths;
 		InBakeState.SetNewBakedOutputObject(InOutputIndex, Identifier, BakedObject);
     }
 

--- a/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIAssetWrapper.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIAssetWrapper.cpp
@@ -451,10 +451,8 @@ UHoudiniPublicAPIAssetWrapper::GetBakedOutputActors_Implementation()
 		for (const auto& BakedPair : BakedOutput.BakedOutputObjects) 
 		{
 			AActor* Actor = BakedPair.Value.GetActorIfValid(true);
-			if (!Actor)
-				continue;
-
-			OutputActors.Add(Actor);
+			if (Actor)
+				OutputActors.Add(Actor);
 
 			// Get valid Foliage Actors
 			OutputActors.Append(BakedPair.Value.GetFoliageActorsIfValid(true));

--- a/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIAssetWrapper.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIAssetWrapper.cpp
@@ -455,6 +455,9 @@ UHoudiniPublicAPIAssetWrapper::GetBakedOutputActors_Implementation()
 				continue;
 
 			OutputActors.Add(Actor);
+
+			// Get valid Foliage Actors
+			OutputActors.Append(BakedPair.Value.GetFoliageActorsIfValid(true));
 		}
 	}
 

--- a/Source/HoudiniEngineRuntime/Private/HoudiniOutput.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniOutput.cpp
@@ -555,6 +555,35 @@ FHoudiniBakedOutputObject::GetBakedSkeletonIfValid(bool bInTryLoad) const
 	return Cast<USkeleton>(Object);
 }
 
+TArray<AActor*>
+FHoudiniBakedOutputObject::GetFoliageActorsIfValid(bool bInTryLoad) const
+{
+	TArray<AActor*> ValidActors;
+
+    for (const FString& ActorPathString : FoliageActors)
+    {
+        FSoftObjectPath ActorPath(ActorPathString);
+
+        if (!ActorPath.IsValid())
+            continue;
+
+        UObject* ResolvedObject = ActorPath.ResolveObject();
+        if (!ResolvedObject && bInTryLoad)
+            ResolvedObject = ActorPath.TryLoad();
+
+        if (!IsValid(ResolvedObject))
+            continue;
+
+        AActor* ResolvedActor = Cast<AActor>(ResolvedObject);
+        if (ResolvedActor)
+        {
+            ValidActors.Add(ResolvedActor);
+        }
+    }
+
+    return ValidActors;
+}
+
 UHoudiniOutput::UHoudiniOutput(const FObjectInitializer & ObjectInitializer)
 	: Super(ObjectInitializer)
 	, Type(EHoudiniOutputType::Invalid)

--- a/Source/HoudiniEngineRuntime/Private/HoudiniOutput.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniOutput.h
@@ -535,6 +535,9 @@ struct HOUDINIENGINERUNTIME_API FHoudiniBakedOutputObject
 		// Returns BakedSkeleton if valid, otherwise nullptr
 		USkeleton* GetBakedSkeletonIfValid(bool bInTryLoad=true) const;
 
+		// Returns the generated or modified Foliage actors if valid
+		TArray<AActor*> GetFoliageActorsIfValid(bool bInTryLoad=true) const;
+
 		// The actor that the baked output was associated with
 		UPROPERTY()
 		FString Actor;
@@ -575,6 +578,10 @@ struct HOUDINIENGINERUNTIME_API FHoudiniBakedOutputObject
 		UPROPERTY()
 		UFoliageType* FoliageType = nullptr;
 
+		// Foliage Actor Instances
+		UPROPERTY()
+		TArray<FString> FoliageActors;
+	
 		// All exported level instance actors.
 		UPROPERTY()
 		TArray<FString> LevelInstanceActors;


### PR DESCRIPTION
Added FoliageActors to the FHoudiniBakedOutputObject, and have them be tracked in GetBakedOutputActors.
This is useful for processing the baked output objects post baking. Eg assign DataLayer, set uproperties etc.