### PR TITLE
Add baked landscape actors to obtained outputs

### DIFF
--- a/Source/HoudiniEngineEditor/Private/HoudiniBakeLandscape.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniBakeLandscape.cpp
@@ -440,6 +440,7 @@ FHoudiniLandscapeBake::MoveCookedToBakedLandscapes(
 						PackageParams);
 
 				Results.Add(BakeActor);
+				BakedOutputObject.Landscape = *BakeActor.Actor->GetPathName();	
 				
 			}
 

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.cpp
@@ -752,7 +752,8 @@ FHoudiniEngineBakeUtils::BakeHoudiniOutputsToActors(
 			BakeSettings,
 			InBakeFolder,
 			BakedObjectData);
-
+		
+		AllBakedActors.Append(BakedLandscapeActors);
 		NewBakedActors.Append(BakedLandscapeActors);
 	}
 

--- a/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIAssetWrapper.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIAssetWrapper.cpp
@@ -51,6 +51,9 @@
 #include "HoudiniPublicAPIBlueprintLib.h"
 #include "HoudiniPublicAPIInputTypes.h"
 #include <Selection.h>
+#include "Landscape.h"
+#include "LandscapeInfo.h"
+#include "LandscapeStreamingProxy.h"
 
 FHoudiniPublicAPIRampPoint::FHoudiniPublicAPIRampPoint()
 	: Position(0)
@@ -451,10 +454,23 @@ UHoudiniPublicAPIAssetWrapper::GetBakedOutputActors_Implementation()
 		for (const auto& BakedPair : BakedOutput.BakedOutputObjects) 
 		{
 			AActor* Actor = BakedPair.Value.GetActorIfValid(true);
-			if (!Actor)
-				continue;
+			if (Actor)
+				OutputActors.Add(Actor);
 
-			OutputActors.Add(Actor);
+			// Get valid Landscape and Proxies
+			if (ALandscape* BakedLandscape = BakedPair.Value.GetLandscapeIfValid(true)) 
+			{
+				OutputActors.Add(Cast<AActor>(BakedLandscape));
+
+				if (ULandscapeInfo* LandscapeInfo = BakedLandscape->GetLandscapeInfo())
+				{
+					for (const TWeakObjectPtr<ALandscapeStreamingProxy>& WeakProxy : LandscapeInfo->StreamingProxies) 
+					{
+						if (ALandscapeStreamingProxy* Proxy = WeakProxy.Get())
+							OutputActors.Add(Cast<AActor>(Proxy));
+					}
+				}
+			}
 		}
 	}
 

--- a/Source/HoudiniEngineRuntime/Private/HoudiniOutput.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniOutput.cpp
@@ -537,6 +537,24 @@ FHoudiniBakedOutputObject::GetLandscapeLayerInfoIfValid(const FName& InLayerName
 	return Cast<ULandscapeLayerInfoObject>(Object);
 }
 
+ALandscape*
+FHoudiniBakedOutputObject::GetLandscapeIfValid(bool bInTryLoad) const
+{
+    const FSoftObjectPath LandscapePath(Landscape);
+
+    if (!LandscapePath.IsValid())
+        return nullptr;
+
+    UObject* Object = LandscapePath.ResolveObject();
+    if (!Object && bInTryLoad)
+        Object = LandscapePath.TryLoad();
+
+    if (!IsValid(Object))
+        return nullptr;
+
+    return Cast<ALandscape>(Object);
+}
+
 USkeleton*
 FHoudiniBakedOutputObject::GetBakedSkeletonIfValid(bool bInTryLoad) const
 {

--- a/Source/HoudiniEngineRuntime/Private/HoudiniOutput.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniOutput.h
@@ -532,6 +532,9 @@ struct HOUDINIENGINERUNTIME_API FHoudiniBakedOutputObject
 		// Returns the ULandscapeLayerInfoObject, if valid and found in LandscapeLayers, otherwise nullptr
 		ULandscapeLayerInfoObject* GetLandscapeLayerInfoIfValid(const FName& InLayerName, const bool bInTryLoad=true) const;
 
+		// Returns the Generated Landscape Actor if valid
+		ALandscape* GetLandscapeIfValid(bool bInTryLoad=true) const;
+
 		// Returns BakedSkeleton if valid, otherwise nullptr
 		USkeleton* GetBakedSkeletonIfValid(bool bInTryLoad=true) const;
 


### PR DESCRIPTION
Added Landscapes to the FHoudiniBakedOutputObject, and have them be tracked in GetBakedOutputActors.
This is useful for processing the baked output objects post baking. Eg assign DataLayer, set uproperties etc.