### PR TITLE
Add baked Instance Actors to obtained outputs

### DIFF
--- a/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIAssetWrapper.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniPublicAPIAssetWrapper.cpp
@@ -451,10 +451,12 @@ UHoudiniPublicAPIAssetWrapper::GetBakedOutputActors_Implementation()
 		for (const auto& BakedPair : BakedOutput.BakedOutputObjects) 
 		{
 			AActor* Actor = BakedPair.Value.GetActorIfValid(true);
-			if (!Actor)
-				continue;
+			if (Actor)
+				OutputActors.Add(Actor);
 
-			OutputActors.Add(Actor);
+			// Get valid instanced actors
+			TArray<AActor*> InstancedActors = BakedPair.Value.GetInstancedActorsIfValid(true);
+			OutputActors.Append(InstancedActors);
 		}
 	}
 

--- a/Source/HoudiniEngineRuntime/Private/HoudiniOutput.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniOutput.cpp
@@ -555,6 +555,34 @@ FHoudiniBakedOutputObject::GetBakedSkeletonIfValid(bool bInTryLoad) const
 	return Cast<USkeleton>(Object);
 }
 
+TArray<AActor*> FHoudiniBakedOutputObject::GetInstancedActorsIfValid(bool bInTryLoad) const
+{
+    TArray<AActor*> ValidActors;
+
+    for (const FString& ActorPathString : InstancedActors)
+    {
+        FSoftObjectPath ActorPath(ActorPathString);
+
+        if (!ActorPath.IsValid())
+            continue;
+
+        UObject* ResolvedObject = ActorPath.ResolveObject();
+        if (!ResolvedObject && bInTryLoad)
+            ResolvedObject = ActorPath.TryLoad();
+
+        if (!IsValid(ResolvedObject))
+            continue;
+
+        AActor* ResolvedActor = Cast<AActor>(ResolvedObject);
+        if (ResolvedActor)
+        {
+            ValidActors.Add(ResolvedActor);
+        }
+    }
+
+    return ValidActors;
+}
+
 UHoudiniOutput::UHoudiniOutput(const FObjectInitializer & ObjectInitializer)
 	: Super(ObjectInitializer)
 	, Type(EHoudiniOutputType::Invalid)

--- a/Source/HoudiniEngineRuntime/Private/HoudiniOutput.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniOutput.h
@@ -535,6 +535,9 @@ struct HOUDINIENGINERUNTIME_API FHoudiniBakedOutputObject
 		// Returns BakedSkeleton if valid, otherwise nullptr
 		USkeleton* GetBakedSkeletonIfValid(bool bInTryLoad=true) const;
 
+		// Returns an array of valid instanced actors
+		TArray<AActor*> GetInstancedActorsIfValid(bool bInTryLoad=true) const;
+
 		// The actor that the baked output was associated with
 		UPROPERTY()
 		FString Actor;


### PR DESCRIPTION
Added Instanced Actors to the FHoudiniBakedOutputObject, and have them be tracked in GetBakedOutputActors.
This is useful for processing the baked output objects post baking. Eg assign DataLayer, set uproperties etc.