### PR TITLE
GetBakeOutlinerFolderAttribute AttributeOwner Copy Paste Fix

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniEngineUtils.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniEngineUtils.cpp
@@ -7660,7 +7660,7 @@ FHoudiniEngineUtils::GetBakeOutlinerFolderAttribute(
 	// ---------------------------------------------
 
 	FHoudiniHapiAccessor Accessor(InGeoId, InPartId, HAPI_UNREAL_ATTRIB_BAKE_OUTLINER_FOLDER);
-	bool bSuccess = Accessor.GetAttributeData(HAPI_ATTROWNER_PRIM, 1, OutBakeOutlinerFolders, InStart, InCount);
+	bool bSuccess = Accessor.GetAttributeData(InAttributeOwner, 1, OutBakeOutlinerFolders, InStart, InCount);
 	if (bSuccess && OutBakeOutlinerFolders.Num() > 0)
 		return true;
 


### PR DESCRIPTION
This bug makes it impossible to set the outliner actor folder other the having the attributes on the Primitives which breaks previous workflows.