### PR TITLE
Removed unused ref

### DIFF
--- a/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestAnimation.cpp
+++ b/Source/HoudiniEngineEditor/Private/Tests/HoudiniEditorTestAnimation.cpp
@@ -142,16 +142,12 @@ bool FHoudiniEditorTestAnimationRoundtrip::RunTest(const FString& Parameters)
 		BakedObjects.GenerateValueArray(BakeOutputObjects);
 		HOUDINI_TEST_EQUAL_ON_FAIL(BakeOutputObjects.Num(), 1, return true);
 
-
-		BakeOutputObjects[0].BakedObject;
-
 		UAnimSequence* AnimSequence  = Cast<UAnimSequence>(StaticLoadObject(UObject::StaticClass(), nullptr, *BakeOutputObjects[0].BakedObject));
 
 		HOUDINI_TEST_NOT_NULL_ON_FAIL(AnimSequence, return true);
 
 		TMap<FName, TArray<FTransform>> OrigAnim = FHoudiniEditorTestAnimationUtils::GetAnimationTransforms(OrigAnimSequence);
 		TMap<FName, TArray<FTransform>> NewAnim = FHoudiniEditorTestAnimationUtils::GetAnimationTransforms(AnimSequence);
-
 
 		HOUDINI_TEST_EQUAL_ON_FAIL(OrigAnim.Num(), NewAnim.Num(), return true);
 


### PR DESCRIPTION
Line 146 --- `BakedOutputObjects[0].BakedObject;` causes the compiler to halt with [-Werror,-Wunused-value]. Removed this line and tidied code spacing.

When compiling on Linux, the error arises from this .ccp file. 

![Screenshot from 2024-11-15 11-11-38](https://github.com/user-attachments/assets/f0749ca7-55df-4895-9fe0-d2317ba30d8b)

After removing the reference, the make compiles successfully and the Engine Plugin works.

![Screenshot from 2024-11-15 11-14-13](https://github.com/user-attachments/assets/fd63f7ec-d9e7-4da7-9572-62fa7dec3561)
