### PR TITLE
Fix Decal Material Actor instantiating.

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniInstanceTranslator.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniInstanceTranslator.cpp
@@ -2516,6 +2516,7 @@ FHoudiniInstanceTranslator::CreateOrUpdateInstancedActorComponent(
 	// Set the number of needed instances
 	InstancedActorComponent->SetNumberOfInstances(InstancedObjectTransforms.Num());
 
+	AActor* ReferenceActor = nullptr;
 	for (int32 Idx = 0; Idx < InstancedObjectTransforms.Num(); Idx++)
 	{
 		// if we already have an actor, we can reuse it
@@ -2526,7 +2527,7 @@ FHoudiniInstanceTranslator::CreateOrUpdateInstancedActorComponent(
 		AActor* CurInstance = InstancedActorComponent->GetInstancedActorAt(Idx);
 		if (!IsValid(CurInstance))
 		{
-			CurInstance = SpawnInstanceActor(CurTransform, SpawnLevel, InstancedActorComponent);
+			CurInstance = SpawnInstanceActor(CurTransform, SpawnLevel, InstancedActorComponent, ReferenceActor);
 			InstancedActorComponent->SetInstanceAt(Idx, CurTransform, CurInstance);
 		}
 		else
@@ -2534,6 +2535,9 @@ FHoudiniInstanceTranslator::CreateOrUpdateInstancedActorComponent(
 			// We can simply update the actor's transform
 			InstancedActorComponent->SetInstanceTransformAt(Idx, CurTransform);	
 		}
+
+		if (!ReferenceActor)
+			ReferenceActor = CurInstance;
 
 		// Keep or clear tags on the instanced actor
 		FHoudiniEngineUtils::KeepOrClearActorTags(CurInstance, true, true, InstancerHGPO);
@@ -3580,6 +3584,7 @@ FHoudiniInstanceTranslator::SpawnInstanceActor(
 	const FTransform& InTransform,
 	ULevel* InSpawnLevel,
 	UHoudiniInstancedActorComponent* InIAC,
+	AActor* ReferenceActor,
 	const FName Name)
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(FHoudiniInstanceTranslator::SpawnInstanceActor);
@@ -3626,7 +3631,7 @@ FHoudiniInstanceTranslator::SpawnInstanceActor(
 		//SpawnParams.Owner = ComponentOuter;
 		SpawnParams.OverrideLevel = InSpawnLevel;
 		SpawnParams.NameMode = FActorSpawnParameters::ESpawnActorNameMode::Requested;
-		SpawnParams.Template = nullptr;
+		SpawnParams.Template = ReferenceActor;  // We need to "duplicate" the previously instantiated actor, when we instantiate a decal material.
 		SpawnParams.bNoFail = true;
 		//SpawnParams.Template = nullptr;
 

--- a/Source/HoudiniEngine/Private/HoudiniInstanceTranslator.h
+++ b/Source/HoudiniEngine/Private/HoudiniInstanceTranslator.h
@@ -453,8 +453,9 @@ struct HOUDINIENGINE_API FHoudiniInstanceTranslator
 		// Relies on editor-only functionalities, so this function is not on the IAC itself
 		static AActor* SpawnInstanceActor(
 			const FTransform& InTransform,
-			ULevel* InSpawnLevel, 
+			ULevel* InSpawnLevel,
 			UHoudiniInstancedActorComponent* InIAC,
+			AActor* ReferenceActor,
 			FName Name = NAME_None);
 
 		// Helper functions for generic property attributes

--- a/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEngineBakeUtils.cpp
@@ -2388,7 +2388,7 @@ FHoudiniEngineBakeUtils::BakeInstancerOutputToActors_IAC(
 
 			FTransform CurrentTransform = CurrentInstancedActor->GetTransform();
 
-			AActor* NewActor = FHoudiniInstanceTranslator::SpawnInstanceActor(CurrentTransform, DesiredLevel, InIAC);
+			AActor* NewActor = FHoudiniInstanceTranslator::SpawnInstanceActor(CurrentTransform, DesiredLevel, InIAC, CurrentInstancedActor);
 			if (!IsValid(NewActor))
 			{
 				continue;


### PR DESCRIPTION
Hi Damien, this is Adrian again!
Yesterday I saw your commit to improve the performance of the actor instancers output.
I just test it, it's really fast! Thank you very much, for this optimization on official HoudiniEngine!

BUT, that commit also cause an issue when trying to instantiate a decal material actor, so here's the fix:
- We need also set FActorSpawnParameters::Template to the last instantiated actor, so that UWorld::SpawnActor will perform as "duplicate", which will fix the issue when trying to instantiate a decal material actor.