### PR TITLE
Add Super calls to `AddReferencedObjects` overrides.

### DIFF
--- a/Source/HoudiniEngineRuntime/Private/HoudiniInstancedActorComponent.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniInstancedActorComponent.cpp
@@ -110,7 +110,9 @@ void UHoudiniInstancedActorComponent::OnComponentDestroyed( bool bDestroyingHier
 void 
 UHoudiniInstancedActorComponent::AddReferencedObjects(UObject * InThis, FReferenceCollector & Collector )
 {
-    UHoudiniInstancedActorComponent * ThisHIAC = Cast< UHoudiniInstancedActorComponent >(InThis);
+	Super::AddReferencedObjects(InThis, Collector);
+	
+	UHoudiniInstancedActorComponent * ThisHIAC = Cast< UHoudiniInstancedActorComponent >(InThis);
     if ( IsValid(ThisHIAC) )
     {
         if ( IsValid(ThisHIAC->InstancedObject) )

--- a/Source/HoudiniEngineRuntime/Private/HoudiniMeshSplitInstancerComponent.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniMeshSplitInstancerComponent.cpp
@@ -106,6 +106,8 @@ UHoudiniMeshSplitInstancerComponent::OnComponentDestroyed( bool bDestroyingHiera
 void 
 UHoudiniMeshSplitInstancerComponent::AddReferencedObjects( UObject * InThis, FReferenceCollector & Collector )
 {
+	Super::AddReferencedObjects(InThis, Collector);
+
     UHoudiniMeshSplitInstancerComponent * ThisMSIC = Cast< UHoudiniMeshSplitInstancerComponent >(InThis);
     if ( IsValid(ThisMSIC) )
     {


### PR DESCRIPTION
This should fix [this issue](https://github.com/sideeffects/HoudiniEngineForUnreal/issues/334).