### PR TITLE
Fix AutoBake to run after processing rather than before.

### DIFF
--- a/Source/HoudiniEngineEditor/Private/HoudiniEditorAssetStateSubsystem.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEditorAssetStateSubsystem.cpp
@@ -54,8 +54,9 @@ UHoudiniEditorAssetStateSubsystem::NotifyOfHoudiniAssetStateChange(UObject* InHo
 	if (!IsValid(HC))
 		return;
 
-	// If we went from PostCook -> PreProcess, the cook was successful, and auto bake is enabled, auto bake!
-	if (InFromState == EHoudiniAssetState::PostCook && InToState == EHoudiniAssetState::PreProcess && HC->WasLastCookSuccessful() && HC->IsBakeAfterNextCookEnabled())
+	// Auto Bake needs to happen after processing has already been handled, otherwise we dont have the nessecary OutputObjects to handle proper baking.
+	// If we went from Processing -> None, the cook was successful, and auto bake is enabled, auto bake!
+	if (InFromState == EHoudiniAssetState::Processing && InToState == EHoudiniAssetState::None && HC->WasLastCookSuccessful() && HC->IsBakeAfterNextCookEnabled())
 	{
 		FHoudiniBakeSettings BakeSettings;
 		BakeSettings.SetFromCookable(HC);


### PR DESCRIPTION
There is a bug when using Auto Bake, where it wont properly bake geo out because the OutputObjects collection is empty.  This collection gets populated by the Processing step of houdini, which means that AutoBake needs to run after cooking & processing.  

We identified this bug during our upgrade from v20 to V21 and i would like to share it with Side FX for all the other unreal devs who use auto bake.