### PR TITLE
Fix crash in FUnrealObjectInputActorProperties::Update related to trying to find the Actor owner for a given ISM blueprint generated component.

### DIFF
--- a/Source/HoudiniEngine/Private/UnrealObjectInputTypes.cpp
+++ b/Source/HoudiniEngine/Private/UnrealObjectInputTypes.cpp
@@ -675,7 +675,7 @@ FUnrealObjectInputActorProperties::Update(const FUnrealObjectInputHAPINodeId& In
 	// parameters which may be set on a per-actor basis.
 
 	// If we don't have a valid mesh component destroy the nodes and return false
-	if(!IsValid(MeshComponent))
+	if(!IsValid(MeshComponent) || !MeshComponent->GetOwner())
 	{
 		DestroyHAPINodes();
 		return false;

--- a/Source/HoudiniEngineEditor/Private/HoudiniEditorAssetStateSubsystem.cpp
+++ b/Source/HoudiniEngineEditor/Private/HoudiniEditorAssetStateSubsystem.cpp
@@ -54,8 +54,9 @@ UHoudiniEditorAssetStateSubsystem::NotifyOfHoudiniAssetStateChange(UObject* InHo
 	if (!IsValid(HC))
 		return;
 
-	// If we went from PostCook -> PreProcess, the cook was successful, and auto bake is enabled, auto bake!
-	if (InFromState == EHoudiniAssetState::PostCook && InToState == EHoudiniAssetState::PreProcess && HC->WasLastCookSuccessful() && HC->IsBakeAfterNextCookEnabled())
+	// Auto Bake needs to happen after processing has already been handled, otherwise we dont have the nessecary OutputObjects to handle proper baking.
+	// If we went from Processing -> None, the cook was successful, and auto bake is enabled, auto bake!
+	if (InFromState == EHoudiniAssetState::Processing && InToState == EHoudiniAssetState::None && HC->WasLastCookSuccessful() && HC->IsBakeAfterNextCookEnabled())
 	{
 		FHoudiniBakeSettings BakeSettings;
 		BakeSettings.SetFromCookable(HC);

--- a/Source/HoudiniEngineRuntime/Private/HoudiniCookable.h
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniCookable.h
@@ -250,6 +250,7 @@ public:
 	// BAKE
 
 	// Previously baked outputs
+	UPROPERTY(DuplicateTransient)
 	TArray<FHoudiniBakedOutput> BakedOutputs;
 
 	// Bake Options


### PR DESCRIPTION
We discovered a crash in the houdini cook pipeline related to PLA actors used as an input for an HDA.  Specifically when a PLA is used as an input, it will grab all the components from the generated blueprint class for that PLA.  When it tries to process the ISM component, it is expecting it to have an Owner Actor.  However, blueprint generated components from the blueprint generated PLA class dont have an actual owner actor.

Preventing this method from running during this scenario, resolves the issues.