### PR TITLE
Fix for cook results transform offset

### DIFF
--- a/Source/HoudiniEngine/Private/HoudiniEngineUtils.cpp
+++ b/Source/HoudiniEngine/Private/HoudiniEngineUtils.cpp
@@ -3238,7 +3238,7 @@ FHoudiniEngineUtils::UploadCookableTransform(UHoudiniCookable* HC)
 	if (!HC->IsFullyLoaded())
 		return false;
 
-	if (HC->CookCount > 0 && HC->GetNodeId() >= 0)
+	if (HC->GetNodeId() >= 0)
 	{
 		if (!FHoudiniEngineUtils::HapiSetAssetTransform(HC->GetNodeId(), HC->ComponentData->Component->GetComponentTransform()))
 			return false;

--- a/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.cpp
+++ b/Source/HoudiniEngineRuntime/Private/HoudiniAssetComponent.cpp
@@ -276,7 +276,7 @@ UHoudiniAssetComponent::UHoudiniAssetComponent(const FObjectInitializer & Object
 	// Initialize the default SM Build settings with the plugin's settings default values
 	StaticMeshBuildSettings_DEPRECATED = FHoudiniEngineRuntimeUtils::GetDefaultMeshBuildSettings();
 
-	//bWantsOnUpdateTransform = true;
+	bWantsOnUpdateTransform = true;
 
 	bIsPDGAssetLinkInitialized_DEPRECATED = false;
 


### PR DESCRIPTION
The root problem is that when creating an HDA actor in Unreal and then transforming it and THEN cooking, the cook results will be offset by an amount equal to the transform done after the actor was created

It appears that the HoudiniAssetComponent does not get notified when the transform changes due to the bWantsOnUpdateTransform flag being false.

Furthermore, even if this flag is true, we don't submit the updated transform to Houdini unless we've done one or more cooks.

Setting the flag to default to true and removing the cook count check fixes the original issue